### PR TITLE
Document all variables set by this module

### DIFF
--- a/cmake/Modules/FindPythonExtra.cmake
+++ b/cmake/Modules/FindPythonExtra.cmake
@@ -19,6 +19,7 @@
 #
 # Output variables:
 #
+# - PythonExtra_FOUND: True if a Python executable was found
 # - PythonExtra_EXTENSION_SUFFIX: The suffix for a Python extension, according
 #    to PEP-3149: https://www.python.org/dev/peps/pep-3149/
 # - PythonExtra_EXTENSION_EXTENSION: The extension for a Python extension. On
@@ -26,6 +27,12 @@
 # - PythonExtra_INCLUDE_DIRS: The paths to the directories where the Python
 #    headers are installed.
 # - PythonExtra_LIBRARIES: The paths to the Python libraries.
+# - PYTHON_SOABI: The shared library file name tag according to PEP-3149:
+#    https://www.python.org/dev/peps/pep-3149/
+#
+# Conditional output variables
+# - PYTHON_EXECUTABLE_DEBUG: If the CMAKE_BUILD_TYPE is Debug and WIN32 is true
+#    then this will be a path to a debug build of the Python interpreter.
 #
 # Example usage:
 #
@@ -207,7 +214,8 @@ include(FindPackageHandleStandardArgs)
 set(_required_vars
   PythonExtra_EXTENSION_EXTENSION
   PythonExtra_INCLUDE_DIRS
-  PythonExtra_LIBRARIES)
+  PythonExtra_LIBRARIES
+  PYTHON_SOABI)
 if(NOT WIN32)
   list(APPEND _required_vars PythonExtra_EXTENSION_SUFFIX)
 elseif("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")


### PR DESCRIPTION
I was looking at this module because of ros2/rosidl_python#137, and I found a couple variables it sets are undocumented. I also added `PYTHON_SOABI` to the list of variables `find_package_handle_standard_args()` thinks are required because it appears to be one.