### PR TITLE
Fail if we try to crosscompile while PYTHON_SOABI is not set.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,5 +13,8 @@ ament_package(
   CONFIG_EXTRAS "python_cmake_module-extras.cmake"
 )
 
+include(cmake/Modules/CheckCrossCompilingSoabi.cmake)
+CheckCrossCompilingSoabi()
+
 install(DIRECTORY cmake
   DESTINATION share/${PROJECT_NAME})

--- a/cmake/Modules/CheckCrossCompilingSoabi.cmake
+++ b/cmake/Modules/CheckCrossCompilingSoabi.cmake
@@ -12,6 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+###############################################################################
+#
+# CheckCrossCompilingSoabi function will exit the compilation early if we
+#   defined a CMAKE_SYSROOT but not the PYTHON_SOABI.
+#
+# Example usage:
+#
+#   CheckCrossCompilingSoabi()
+#
+###############################################################################
 function(CheckCrossCompilingSoabi)
   set(_python_code
     "from sysconfig import get_config_var"

--- a/cmake/Modules/CheckCrossCompilingSoabi.cmake
+++ b/cmake/Modules/CheckCrossCompilingSoabi.cmake
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 function(CheckCrossCompilingSoabi)
+  set(_python_code
+    "from sysconfig import get_config_var"
+    "print(get_config_var('SOABI'))"
+  )
   if(NOT DEFINED PYTHON_SOABI AND DEFINED CMAKE_SYSROOT)
     message(FATAL_ERROR "We detected you defined a sysroot thus crosscompiling.\n"
       "You have to define the PYTHON_SOABI variable in the toolchain file, which looks like cpython-39-x86_64-linux-gnu or cpython-39-aarch64-linux-gnu.\n"

--- a/cmake/Modules/CheckCrossCompilingSoabi.cmake
+++ b/cmake/Modules/CheckCrossCompilingSoabi.cmake
@@ -1,0 +1,30 @@
+# Copyright 2022 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function(CheckCrossCompilingSoabi)
+  if(NOT DEFINED PYTHON_SOABI AND DEFINED CMAKE_SYSROOT)
+    message(FATAL_ERROR "We detected you defined a sysroot thus crosscompiling.\n"
+      "You have to define the PYTHON_SOABI variable in the toolchain file, which looks like cpython-39-x86_64-linux-gnu or cpython-39-aarch64-linux-gnu.\n"
+      ""
+      "To find the correct PYTHON_SOABI value, you can execute the following from the target:\n"
+      "python3 -c \"${_python_code}\"\n"
+      ""
+      "Run it with qemu with: (expecting aarch64 as your \n"
+      "qemu-aarch64-static -L ${CMAKE_SYSROOT} ${CMAKE_SYSROOT}/usr/bin/python3 -c \"${_python_code}\"\n"
+      ""
+      "The toolchain should look like:\n"
+      "set(PYTHON_SOABI cpython-39-aarch64-linux-gnu)\n"
+    )
+  endif()
+endfunction()

--- a/cmake/Modules/FindPythonExtra.cmake
+++ b/cmake/Modules/FindPythonExtra.cmake
@@ -154,6 +154,8 @@ if(PYTHONINTERP_FOUND)
       "from sysconfig import get_config_var"
       "print(get_config_var('SOABI'))"
     )
+    include(CheckCrossCompilingSoabi)
+    CheckCrossCompilingSoabi()
     execute_process(
       COMMAND
       "${PYTHON_EXECUTABLE}"

--- a/cmake/Modules/FindPythonExtra.cmake
+++ b/cmake/Modules/FindPythonExtra.cmake
@@ -26,6 +26,8 @@
 # - PythonExtra_INCLUDE_DIRS: The paths to the directories where the Python
 #    headers are installed.
 # - PythonExtra_LIBRARIES: The paths to the Python libraries.
+# - PYTHON_MODULE_EXTENSION: The full module extension, as the suffix+extension.
+#    This is required for packages using pybind11 when crosscompiling.
 #
 # Example usage:
 #
@@ -219,3 +221,7 @@ find_package_handle_standard_args(PythonExtra
   FOUND_VAR PythonExtra_FOUND
   REQUIRED_VARS ${_required_vars}
 )
+
+if(DEFINED CMAKE_SYSROOT)
+  set(PYTHON_MODULE_EXTENSION ${PythonExtra_EXTENSION_SUFFIX}${PythonExtra_EXTENSION_EXTENSION})
+endif()


### PR DESCRIPTION
[NOTE: This would be a workaround until [python_cmake_module#7](https://github.com/ros2/python_cmake_module/pull/7), which I couldn't make work locally]

When cross-compiling, we need the PYTHON_SOABI variable to be set.
The current method was using the **system** python interpreter instead of the **target** one, causing incorrect variable naming as in: https://github.com/ros2/python_cmake_module/issues/9 and https://github.com/ros2/pybind11_vendor/issues/16

The current methodology is to provide to people cross-compiling with a sysroot (found using **CMAKE_SYSROOT**) with an user friendly error message to explain which variable should be set. (PYTHON_SOABI)

The possibly better way would be to execute the target python version with qemu-${ARCH}-static. This means we need to **find the arch**, **check for qemu for this arch**, **find Python within the sysroot** and **execute it**. 
One argument against it is often a the DevOps creating the sysroot will have qemu, but it is not systematic for the developer side, thus creating possibly a "it works on my machine" clash against the DevOps.

Another consideration is, as we are using a sysroot, the **python version** will likely be fixed;

Sample output:
```cmake
Starting >>> python_cmake_module
--- stderr: python_cmake_module                            
CMake Error at cmake/Modules/CheckCrossCompilingSoabi.cmake:31 (message):
  We detected you defined a sysroot thus crosscompiling.

  You have to define the PYTHON_SOABI variable in the toolchain file, which
  looks like cpython-39-x86_64-linux-gnu or cpython-39-aarch64-linux-gnu.

  To find the correct PYTHON_SOABI value, you can execute the following from
  the target:

  python3 -c "from sysconfig import
  get_config_var;print(get_config_var('SOABI'))"

  Run it with qemu with: (expecting aarch64 as your

  qemu-aarch64-static -L /opt/bosch/sysroot
  /opt/bosch/sysroot/usr/bin/python3 -c "from sysconfig import
  get_config_var;print(get_config_var('SOABI'))"

  The toolchain should look like:

  set(PYTHON_SOABI cpython-39-aarch64-linux-gnu)

Call Stack (most recent call first):
  CMakeLists.txt:17 (CheckCrossCompilingSoabi)


---
Failed   <<< python_cmake_module [0.23s, exited with code 1]

Summary: 36 packages finished [25.8s]
  1 package failed: python_cmake_module
  2 packages had stderr output: python_cmake_module uncrustify_vendor
```